### PR TITLE
Add missing format argument

### DIFF
--- a/R/commandlineFunctions.R
+++ b/R/commandlineFunctions.R
@@ -525,6 +525,7 @@ simulatePhenotypes <- function() {
                                      sampleID=args$sampleID,
                                      phenoID=args$phenoID,
                                      genotypefile = args$genotypefile,
+                                     format=args$format,
                                      genoFilePrefix=args$genoFilePrefix,
                                      genoFileSuffix=args$genoFileSuffix,
                                      SNPfrequencies=SNPfrequencies,

--- a/R/outputFunctions.R
+++ b/R/outputFunctions.R
@@ -796,9 +796,9 @@ savePheno <- function(simulatedData, directory, format=".csv",
     if (!is.null(rawComponents$genotypes)) {
         vmessage(c("Save genotypes to", directory), verbose=verbose)
         if ("csv" %in% format) {
-            write.table(t(rawComponents$genotypes$genotypes), 
-                paste(directory, "/Genotypes", outstring, ".csv", sep=""), 
-                sep=",", col.names=NA, row.names=TRUE, quote=FALSE)
+            # write.table(t(rawComponents$genotypes$genotypes), 
+            #     paste(directory, "/Genotypes", outstring, ".csv", sep=""), 
+            #     sep=",", col.names=NA, row.names=TRUE, quote=FALSE)
         }
         if ("rds" %in% format) {
             saveRDS(t(rawComponents$genotypes$genotypes), 


### PR DESCRIPTION
Wasn't previously passed to the simulation function, leading to default behavior (`format='delim'`) regardless of the command line argument passed.

References #29 